### PR TITLE
.prettierignore と .gitignore を共通化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,5 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,linux,visualstudiocode,node
+/.devcontainer
+/.vscode

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
-/.devcontainer
-/.vscode
+.gitignore


### PR DESCRIPTION
## 概要
prettier による format 対象ファイルの除外条件として、.gitignore を活用する。
参考：https://prettier.io/docs/en/install
> Tip! Base your .prettierignore on .gitignore and .eslintignore (if you have one).

## 変更内容
- .prettierignore ファイルを .gitignore の symlink に変更